### PR TITLE
Fix ping notes section header, to avoid being included in help output

### DIFF
--- a/scripts/ping.coffee
+++ b/scripts/ping.coffee
@@ -6,7 +6,7 @@
 #   hubot echo <text> - Reply back with <text>
 #   hubot time - Reply with current time
 #
-# Note:
+# Notes:
 #   This is adapted from hubot-diagnostic with removals to avoid conflict with timezones.coffee
 #
 # Author:


### PR DESCRIPTION
This fixes the first line from being included:

![](https://cl.ly/3I3R3L392z36/Image%202017-06-15%20at%2010.21.14%20PM.png)