### PR TITLE
remove google images

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,6 +1,5 @@
 [
   "hubot-help",
-  "hubot-google-images",
   "hubot-redis-brain",
   "hubot-rules",
   "hubot-shipit"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "description": "A hubot install for the Hubot community",
   "dependencies": {
     "hubot": "^2.19.0",
-    "hubot-google-images": "^0.2.6",
-    "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.2.0",
     "hubot-redis-brain": "0.0.3",
     "hubot-rules": "^0.1.1",


### PR DESCRIPTION
This removes google images, since it doesn't work without configuration. I'm trying to trim down `help` to actually show what is useful, which will probably end up being nothing 😅 

For like `animate`, it'd be better to do turn on Giphy integration anyways.