### PR TITLE
NLP-based Laws of Robotics

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,6 +2,5 @@
   "hubot-help",
   "hubot-google-images",
   "hubot-redis-brain",
-  "hubot-rules",
   "hubot-shipit"
 ]

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "private": true,
   "description": "A hubot install for the Hubot community",
   "dependencies": {
+    "bravey": "github:braveyjs/bravey",
     "hubot": "^2.19.0",
     "hubot-google-images": "^0.2.6",
     "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.2.0",
     "hubot-redis-brain": "0.0.3",
-    "hubot-rules": "^0.1.1",
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^4.3.4",
     "moment-timezone": "^0.5.13"

--- a/scripts/rules.coffee
+++ b/scripts/rules.coffee
@@ -14,28 +14,34 @@ rules = [
 
 {inspect} = require 'util'
 module.exports = (robot) ->
-  rulesNlp = new Bravey.Nlp.Fuzzy()
-  rulesNlp.addIntent "explain_the_rules", []
-  rulesNlp.addDocument "Does #{robot.name} know the rules?", "explain_the_rules"
-  rulesNlp.addDocument "#{robot.name} what are the rules?", "explain_the_rules"
-  rulesNlp.addDocument "@#{robot.name} what are the rules?", "explain_the_rules"
-  rulesNlp.addDocument "does hubot know the laws of rules of robotics", "explain_the_rules"
-  rulesNlp.addDocument "does hubot know the three laws of rules of robotics", "explain_the_rules"
-  rulesNlp.addDocument "does hubot know the 3 laws of rules of robotics", "explain_the_rules"
-  rulesNlp.addDocument "has hubot read the Robot series?", "explain_the_rules"
-  rulesNlp.addDocument "does hubot read Asimov?", "explain_the_rules"
+
+  robot.bravey = new Bravey.Nlp.Fuzzy()
+  robot.bravey.addIntent "explain_the_rules", []
+  robot.bravey.addDocument "Does #{robot.name} know the rules?", "explain_the_rules"
+  robot.bravey.addDocument "#{robot.name} what are the rules?", "explain_the_rules"
+  robot.bravey.addDocument "@#{robot.name} what are the rules?", "explain_the_rules"
+  robot.bravey.addDocument "does hubot know the laws of rules of robotics", "explain_the_rules"
+  robot.bravey.addDocument "does hubot know the three laws of rules of robotics", "explain_the_rules"
+  robot.bravey.addDocument "does hubot know the 3 laws of rules of robotics", "explain_the_rules"
+  robot.bravey.addDocument "has hubot read the Robot series?", "explain_the_rules"
+  robot.bravey.addDocument "does hubot read Asimov?", "explain_the_rules"
+
+  robot.receiveMiddleware (context, next, done) ->
+    message = context.response.message
+    if message.text?
+      message.bravey = robot.bravey.test(message.text)
+
+    next(done)
 
   robot.listen(
     (message) ->
       return unless message.text
-
-      result = rulesNlp.test(message.text)
-      console.log inspect result
-
-      return unless result.intent is "explain_the_rules"
+      console.log inspect message.bravey
+      return unless message.bravey.intent is "explain_the_rules"
 
       # we only train for one specific intent. that means we only care when it is _reallly_ highly scored
-      result.score > 0.999
+      if message.bravey.score > 0.999
+        message.bravey
     (response) ->
       response.send rules.join('\n')
   )

--- a/scripts/rules.coffee
+++ b/scripts/rules.coffee
@@ -1,3 +1,8 @@
+# Description:
+#   Law of Robotics, as understood by Hubot
+#
+# Commands
+#   hubot what are the rules? - hubot explains the Laws of Robotics, as it understands them
 Bravey = require("bravey")
 
 rules = [
@@ -19,7 +24,6 @@ module.exports = (robot) ->
   rulesNlp.addDocument "does hubot know the 3 laws of rules of robotics", "explain_the_rules"
   rulesNlp.addDocument "has hubot read the Robot series?", "explain_the_rules"
   rulesNlp.addDocument "does hubot read Asimov?", "explain_the_rules"
-
 
   robot.listen(
     (message) ->

--- a/scripts/rules.coffee
+++ b/scripts/rules.coffee
@@ -1,0 +1,38 @@
+Bravey = require("bravey")
+
+rules = [
+  "0. A robot may not harm humanity, or, by inaction, allow humanity to come to harm.",
+  "1. A robot may not injure a human being or, through inaction, allow a human being to come to harm.",
+  "2. A robot must obey any orders given to it by human beings, except where such orders would conflict with the First Law.",
+  "3. A robot must protect its own existence as long as such protection does not conflict with the First or Second Law."
+  ]
+
+{inspect} = require 'util'
+module.exports = (robot) ->
+  rulesNlp = new Bravey.Nlp.Fuzzy()
+  rulesNlp.addIntent "explain_the_rules", []
+  rulesNlp.addDocument "Does #{robot.name} know the rules?", "explain_the_rules"
+  rulesNlp.addDocument "#{robot.name} what are the rules?", "explain_the_rules"
+  rulesNlp.addDocument "@#{robot.name} what are the rules?", "explain_the_rules"
+  rulesNlp.addDocument "does hubot know the laws of rules of robotics", "explain_the_rules"
+  rulesNlp.addDocument "does hubot know the three laws of rules of robotics", "explain_the_rules"
+  rulesNlp.addDocument "does hubot know the 3 laws of rules of robotics", "explain_the_rules"
+  rulesNlp.addDocument "has hubot read the Robot series?", "explain_the_rules"
+  rulesNlp.addDocument "does hubot read Asimov?", "explain_the_rules"
+
+
+  robot.listen(
+    (message) ->
+      return unless message.text
+
+      result = rulesNlp.test(message.text)
+      console.log inspect result
+
+      return unless result.intent is "explain_the_rules"
+
+      # we only train for one specific intent. that means we only care when it is _reallly_ highly scored
+      result.score > 0.999
+    (response) ->
+      response.send rules.join('\n')
+  )
+

--- a/scripts/rules.coffee
+++ b/scripts/rules.coffee
@@ -17,6 +17,16 @@ module.exports = (robot) ->
 
   robot.bravey = new Bravey.Nlp.Fuzzy()
   robot.bravey.addIntent "explain_the_rules", []
+
+  rulesSubject = new Bravey.StringEntityRecognizer("the_rules_subject")
+  rulesSubject.addMatch "asimov", "asimov"
+  rulesSubject.addMatch "asimov", "isaac asimov"
+  rulesSubject.addMatch "robot_series", "robot series"
+  rulesSubject.addMatch "robot_series", "the robot series"
+  rulesSubject.addMatch "laws_of_robotics", "the rules"
+  rulesSubject.addMatch "laws_of_robotics", "the laws of robotics"
+  rulesSubject.addMatch "laws_of_robotics", "the 3 laws of robotics"
+
   robot.bravey.addDocument "Does #{robot.name} know the rules?", "explain_the_rules"
   robot.bravey.addDocument "#{robot.name} what are the rules?", "explain_the_rules"
   robot.bravey.addDocument "@#{robot.name} what are the rules?", "explain_the_rules"
@@ -33,16 +43,18 @@ module.exports = (robot) ->
 
     next(done)
 
-  robot.listen(
-    (message) ->
-      return unless message.text
-      console.log inspect message.bravey
-      return unless message.bravey.intent is "explain_the_rules"
+  robot.intent = (name, cb) ->
+    robot.listen(
+      (message) ->
+        return unless message.text
+        console.log inspect message.bravey
+        return unless message.bravey.intent is name
 
-      # we only train for one specific intent. that means we only care when it is _reallly_ highly scored
-      if message.bravey.score > 0.999
-        message.bravey
-    (response) ->
-      response.send rules.join('\n')
-  )
+        # we only train for one specific intent. that means we only care when it is _reallly_ highly scored
+        if message.bravey.score > 0.999
+          message.bravey
+      cb
+    )
 
+  robot.intent 'explain_the_rules', (res) ->
+    res.send rules.join('\n')


### PR DESCRIPTION
While looking at removing some scripts in https://github.com/hubotio/hubot-for-hubot/pull/10 I got to looking at `rules.coffee`:

> 0. A robot may not harm humanity, or, by inaction, allow humanity to come to harm.
>1. A robot may not injure a human being or, through inaction, allow a human being to come to harm.
>2. A robot must obey any orders given to it by human beings, except where such orders would conflict with the First Law.
>3. A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.

The problem with scripts like this is that they expect you to ask hubot directly "hubot do you know the rules?" or something like that. That limits the potential humor of hubot knowing the rules of robotics, since people talking _about_ hubot instead of to hubot would not trigger the output.

I have been thinking about how to apply NLP to hubot for awhile. I thought it would be possible to use a [custom listener](https://github.com/hubotio/hubot/blob/master/docs/scripting.md#custom-listeners) to be able to do the processing to determine if something said matches. I did a bit of research on nodejs libraries to do the detection of intents, and the only one that did intent processing was [Bravey](https://braveyjs.github.io/).

This PR builds a  Bravey fuzzy NLP of some phrases that could be referring to the Laws of Robotics, and then has a custom listener that tries to check if the intent was to explain the laws. Since we only train those phrases, even unrelated text can have a relatively high score, so I just hard-coded a score of like 0.999 to prevent unrelated things from triggering it.

Here's some example usage:

![](https://cl.ly/1T2U1T0J2L2I/Image%202017-06-15%20at%2011.16.22%20PM.png)

I don't think I'd actually want to merge this as is. If possible, it'd be nice to 'dark ship' this to see if there's a way to collect data on what would be interpretted as asking for the rules, so we know we aren't going to annoy people, but surprise and delight them when (or probably baffle) when hubot chimes in.

Another safeguard against that might be rate limiting how often this triggers, which could be done with listener middleware.