### PR TITLE
Update to hubot 3, as well as updating scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "description": "A hubot install for the Hubot community",
   "dependencies": {
     "coffee-script": "^1.12.6",
-    "hubot": "^2.19.0",
-    "hubot-help": "^0.2.0",
-    "hubot-redis-brain": "0.0.3",
-    "hubot-rules": "^0.1.1",
-    "hubot-shipit": "^0.2.0",
+    "hubot": "^3.0.1",
+    "hubot-help": "^1.0.1",
+    "hubot-redis-brain": "^1.0.0",
+    "hubot-rules": "^1.0.0",
+    "hubot-shipit": "^0.2.1",
     "hubot-slack": "^4.3.4",
     "mocha": "^3.4.2",
     "moment-timezone": "^0.5.13"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "co": "^4.6.0",
-    "hubot-test-helper": "^1.5.1"
+    "hubot-test-helper": "^1.6.0"
   },
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register"


### PR DESCRIPTION
This fails for me in development, for some reason:

```
$ npm test

> @ test /Users/technicalpickles/hubotio/hubot-for-hubot
> mocha --compilers coffee:coffee-script/register



  hubot
    user says hi to hubot
[Fri Jun 30 2017 17:39:02 GMT-0400 (EDT)] ERROR Cannot load adapter null - Error: Cannot find module 'hubot-null'
npm ERR! Test failed.  See above for more details.
```

hubot-test-helper [subclasses robot and handles making its own adapter](https://github.com/mtsmfm/hubot-test-helper/blob/master/src/index.coffee#L11). The error message is coming from [robot's loadAdapter](https://github.com/hubotio/hubot/blob/master/src/robot.js#L505), which is weird because hubot-test-helper [should be overriding it](https://github.com/mtsmfm/hubot-test-helper/blob/master/src/index.coffee#L17-L18)

What is weird to me is that Travis is passing 🤔 

cc  @gr2m https://github.com/hubotio/evolution/pull/4